### PR TITLE
Bug in get_sample_size

### DIFF
--- a/texmex_python/reader.py
+++ b/texmex_python/reader.py
@@ -43,7 +43,7 @@ def get_sample_size(filename, typechar, typesize):
     with open(filename, 'rb') as f:
         d_bin = f.read(4)
         dim, = struct.unpack('i', d_bin)
-        return int(os.path.getsize(filename) / dim / typesize)
+        return int(os.path.getsize(filename) / (typesize * dim + 4))
 
 
 # float


### PR DESCRIPTION
Solved a bug in get_sample_size. Current impl returns a slightly wrong result. 

As the [official website](http://corpus-texmex.irisa.fr/) says, each vector takes:
- `4 + d*4` bytes for .fvecs
- `4 + d*4` bytes for .ivecs
- `4 + d` bytes for .bvecs

So the return statement should be `N / (t*d + 4)`, where `t` is specified by a typesize parameter (4 for ivecs or fvecs, and 1 for bvecs).

WIth this PR, the function returns the correct value:
```python
p1 = "sift_query.fvecs"  # N=10000
p2 = "bigann_query.bvecs"   # N=10000
```
```python
# Before
print(texmex_python.reader.get_fvec_size(p1))  # 10078  wrong
print(texmex_python.reader.get_bvec_size(p2))  # 10312  wrong
```
```python
# After
print(texmex_python.reader.get_fvec_size(p1))  # 10000  ok
print(texmex_python.reader.get_bvec_size(p2))  # 10000  ok
```